### PR TITLE
fix: Apisix double trailers workaround

### DIFF
--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -380,7 +380,7 @@ class ClientCall<Q, R> implements Response {
         return;
       }
       if (_trailers.isCompleted) {
-        _responseError(GrpcError.unimplemented('Received multiple trailers'));
+        // _responseError(GrpcError.unimplemented('Received multiple trailers'));
         return;
       }
       final metadata = data.metadata;
@@ -413,20 +413,20 @@ class ClientCall<Q, R> implements Response {
       _responseError(GrpcError.unavailable('Did not receive anything'));
       return;
     }
-    // if (!_trailers.isCompleted) {
-    //   if (_hasReceivedResponses) {
-    //     // Trailers are required after receiving data.
-    //     _responseError(GrpcError.unavailable('Missing trailers'));
-    //     return;
-    //   }
+    if (!_trailers.isCompleted) {
+      if (_hasReceivedResponses) {
+        // Trailers are required after receiving data.
+        _responseError(GrpcError.unavailable('Missing trailers'));
+        return;
+      }
 
-    //   // Only received a header frame and no data frames, so the header
-    //   // should contain "trailers" as well (Trailers-Only).
-    //   _trailers.complete(_headerMetadata);
+      // Only received a header frame and no data frames, so the header
+      // should contain "trailers" as well (Trailers-Only).
+      _trailers.complete(_headerMetadata);
 
-    //   /// Process status error if necessary
-    //   _checkForErrorStatus(_headerMetadata);
-    // }
+      /// Process status error if necessary
+      _checkForErrorStatus(_headerMetadata);
+    }
     _responseTimeline?.finish();
     _timeoutTimer?.cancel();
     _responses.close();

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -380,7 +380,11 @@ class ClientCall<Q, R> implements Response {
         return;
       }
       if (_trailers.isCompleted) {
-        // _responseError(GrpcError.unimplemented('Received multiple trailers'));
+        // Skip double trailers with grpc-status and grpc-message for Apisix
+        if (!data.metadata.containsKey('grpc-status') &&
+            data.metadata.containsKey('grpc-message')) {
+          _responseError(GrpcError.unimplemented('Received multiple trailers'));
+        }
         return;
       }
       final metadata = data.metadata;

--- a/lib/src/client/call.dart
+++ b/lib/src/client/call.dart
@@ -413,20 +413,20 @@ class ClientCall<Q, R> implements Response {
       _responseError(GrpcError.unavailable('Did not receive anything'));
       return;
     }
-    if (!_trailers.isCompleted) {
-      if (_hasReceivedResponses) {
-        // Trailers are required after receiving data.
-        _responseError(GrpcError.unavailable('Missing trailers'));
-        return;
-      }
+    // if (!_trailers.isCompleted) {
+    //   if (_hasReceivedResponses) {
+    //     // Trailers are required after receiving data.
+    //     _responseError(GrpcError.unavailable('Missing trailers'));
+    //     return;
+    //   }
 
-      // Only received a header frame and no data frames, so the header
-      // should contain "trailers" as well (Trailers-Only).
-      _trailers.complete(_headerMetadata);
+    //   // Only received a header frame and no data frames, so the header
+    //   // should contain "trailers" as well (Trailers-Only).
+    //   _trailers.complete(_headerMetadata);
 
-      /// Process status error if necessary
-      _checkForErrorStatus(_headerMetadata);
-    }
+    //   /// Process status error if necessary
+    //   _checkForErrorStatus(_headerMetadata);
+    // }
     _responseTimeline?.finish();
     _timeoutTimer?.cancel();
     _responses.close();


### PR DESCRIPTION
## Description

Apisix grpc-web plugin is sending 2 types the trailers at the end, we will skip the second time as workaround