### PR TITLE
feature: grpc endpoint prefix for web and native

### DIFF
--- a/lib/src/client/http2_channel.dart
+++ b/lib/src/client/http2_channel.dart
@@ -30,18 +30,23 @@ class ClientChannel extends ClientChannelBase {
   /// case it can be a Unix Domain Socket address.
   final Object host;
   final int port;
+  final String prefixPath;
   final ChannelOptions options;
 
   ClientChannel(
     this.host, {
     this.port = 443,
+    this.prefixPath = '',
     this.options = const ChannelOptions(),
     super.channelShutdownHandler,
-  });
+  }) : assert(
+            prefixPath.isEmpty ||
+                prefixPath.isNotEmpty && !prefixPath.endsWith('/'),
+            'prefixPath must be empty or does not start and end with /');
 
   @override
   ClientConnection createConnection() =>
-      Http2ClientConnection(host, port, options);
+      Http2ClientConnection(host, port, options, prefixPath: '/$prefixPath');
 }
 
 class ClientTransportConnectorChannel extends ClientChannelBase {

--- a/lib/src/client/http2_connection.dart
+++ b/lib/src/client/http2_connection.dart
@@ -62,11 +62,15 @@ class Http2ClientConnection implements connection.ClientConnection {
 
   ClientKeepAlive? keepAliveManager;
 
-  Http2ClientConnection(Object host, int port, this.options)
+  final String prefixPath;
+
+  Http2ClientConnection(Object host, int port, this.options,
+      {this.prefixPath = ''})
       : _transportConnector = SocketTransportConnector(host, port, options);
 
   Http2ClientConnection.fromClientTransportConnector(
-      this._transportConnector, this.options);
+      this._transportConnector, this.options,
+      {this.prefixPath = ''});
 
   ChannelCredentials get credentials => options.credentials;
 
@@ -178,7 +182,7 @@ class Http2ClientConnection implements connection.ClientConnection {
     final headers = createCallHeaders(
       credentials.isSecure,
       _transportConnector.authority,
-      path,
+      prefixPath + path,
       timeout,
       metadata,
       compressionCodec,

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -146,10 +146,11 @@ class XhrTransportStream implements GrpcTransportStream {
 
 class XhrClientConnection implements ClientConnection {
   final Uri uri;
+  final String prefixPath;
 
   final _requests = <XhrTransportStream>{};
 
-  XhrClientConnection(this.uri);
+  XhrClientConnection(this.uri, {this.prefixPath = ''});
 
   @override
   String get authority => uri.authority;
@@ -179,7 +180,12 @@ class XhrClientConnection implements ClientConnection {
       metadata['X-Grpc-Web'] = '1';
     }
 
-    var requestUri = uri.resolve(path);
+    if (prefixPath.isNotEmpty && prefixPath.endsWith('/')) {
+      throw ArgumentError.value(
+          prefixPath, 'prefixPath', 'must not end with a slash');
+    }
+
+    var requestUri = uri.resolve('$prefixPath$path');
     if (callOptions is WebCallOptions &&
         callOptions.bypassCorsPreflight == true) {
       requestUri = cors.moveHttpHeadersToQueryParam(metadata, requestUri);

--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -180,12 +180,7 @@ class XhrClientConnection implements ClientConnection {
       metadata['X-Grpc-Web'] = '1';
     }
 
-    if (prefixPath.isNotEmpty && prefixPath.endsWith('/')) {
-      throw ArgumentError.value(
-          prefixPath, 'prefixPath', 'must not end with a slash');
-    }
-
-    var requestUri = uri.resolve('$prefixPath$path');
+    var requestUri = uri.resolve(prefixPath + path);
     if (callOptions is WebCallOptions &&
         callOptions.bypassCorsPreflight == true) {
       requestUri = cors.moveHttpHeadersToQueryParam(metadata, requestUri);

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -21,10 +21,17 @@ import 'transport/xhr_transport.dart';
 class GrpcWebClientChannel extends ClientChannelBase {
   final Uri uri;
 
-  GrpcWebClientChannel.xhr(this.uri, {super.channelShutdownHandler});
+  /// The path to prefix to the URI when making requests. Omit '/' at start and end.
+  final String prefixPath;
+
+  GrpcWebClientChannel.xhr(this.uri,
+      {this.prefixPath = '', super.channelShutdownHandler});
 
   @override
   ClientConnection createConnection() {
-    return XhrClientConnection(uri);
+    return XhrClientConnection(
+      uri,
+      prefixPath: prefixPath,
+    );
   }
 }

--- a/lib/src/client/web_channel.dart
+++ b/lib/src/client/web_channel.dart
@@ -25,7 +25,11 @@ class GrpcWebClientChannel extends ClientChannelBase {
   final String prefixPath;
 
   GrpcWebClientChannel.xhr(this.uri,
-      {this.prefixPath = '', super.channelShutdownHandler});
+      {this.prefixPath = '', super.channelShutdownHandler})
+      : assert(
+            prefixPath.isEmpty ||
+                prefixPath.isNotEmpty && !prefixPath.endsWith('/'),
+            'prefixPath must be empty or does not start and end with /');
 
   @override
   ClientConnection createConnection() {


### PR DESCRIPTION
## Description

There are some prefixes that we can assign in gateways to redirect to our services. 
This feature enable an option `prefixPath` for that purpose

### gRPC Native
```dart
    ClientChannel(
        host,
        port: port,
        prefixPath: nativePrefixPath,
        options: ChannelOptions(
          connectTimeout: const Duration(seconds: 6),
          connectionTimeout: const Duration(seconds: 6),
          idleTimeout: const Duration(seconds: 6),
          codecRegistry:
              CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
        ),
      )
```


### gRPC Web
```dart
      GrpcWebClientChannel.xhr(
        Uri.parse('$host:$port'),
        prefixPath: webPrefixPath,
      );
```